### PR TITLE
More languages for Microsoft

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1,6 +1,6 @@
 ---
 title: Companies
-date: "2020-06-02"
+date: "2021-07-15"
 description: List of companies that use GitHub
 author: Daniel Schildt
 language: en
@@ -90,9 +90,9 @@ If you notice a notable company in GitHub with something interesting in their pu
 | [Manifold (Arigato Machine Inc.)](https://github.com/manifoldco) | C#, CSS, Elixir, Go, HTML, Java, JavaScript, Jupyter Notebook, PHP, Python, Ruby, Shell, TypeScript |
 | [Medium](https://github.com/Medium) | C++, Go, Java, JavaScript, Objective-C, Objective-C++, Markdown, PHP, Python, Shell, XML |
 | [Meltwater](https://github.com/meltwater) | C, C++, CoffeeScript, CSS, Dockerfile, Elixir, Erlang, Go, HCL, HTML, Java, JavaScript, Kotlin, Lua, Makefile, PHP, Puppet, Python, Ruby, Shell, Smarty |
-| [Microsoft - Office Developer](https://github.com/OfficeDev) | ASP, Batchfile, C#, CSS, HTML, Java, JavaScript, Objective-C, PHP, PowerShell, Python, Ruby, Swift, TypeScript, Visual Basic |
+| [Microsoft - Office Developer](https://github.com/OfficeDev) | ASP, Batchfile, C#, CSS, HTML, Java, JavaScript, Julia, Objective-C, PHP, PowerShell, Python, Ruby, Swift, TypeScript, Visual Basic |
 | [Microsoft - Xamarin](https://github.com/xamarin) | C#, C, C++, F#, JavaScript, Java, Ruby, HTML |
-| [Microsoft](https://github.com/Microsoft) | PowerShell, C, C++, C#, TypeScript, F#, Go, JavaScript, Scala, Markdown, Java, Groovy, PHP, Python, CSS, HTML, GLSL, Objective-C, Ruby, Logos |
+| [Microsoft](https://github.com/Microsoft) | PowerShell, C, C++, C#, TypeScript, F#, Go, JavaScript, Scala, Markdown, Java, Groovy, PHP, Python, R, Ruby, CSS, HTML, GLSL, Objective-C, Logos |
 | [Mozilla - MDN Web Docs](https://github.com/mdn) | CSS, HTML, JavaScript, PHP, Python, Shell, Smarty, WebAssembly |
 | [Mozilla Appmaker](https://github.com/mozilla-appmaker) | CoffeeScript, CSS, HTML, JavaScript, Python |
 | [Mozilla Boot2Gecko / Firefox OS](https://github.com/mozilla-b2g) | C, C++, CSS, HTML, Java, JavaScript, Makefile, Python, Shell |


### PR DESCRIPTION
I do not represent Microsoft.

Do you just need some proof of a language related to a company or some minimum about of use or official statement? Your repo seems just your private one so I guess ou can do whatever you like.

I just know they have two Julia packages, see at:
https://github.com/microsoft?q=&type=&language=julia&sort=

See also there: https://github.com/microsoftopensource

I know Google-research (but not Google main github) has Julia:

https://github.com/google-research?q=&type=&language=julia&sort=  

I'm not adding that for now, while arguable should, three repos there, all related I believe. They may be something major I just can't judge. For Microsoft one seems intriguing with lot of work put into it, and the other to support Azure for Julia, so seem they're really promoting Julia in a sense, thus justified.

I know Microsoft is heavily involved in R, promoting it, and has more R repos so seems justified for sure. Actually they (and many companies) have lots more languages on Github.

I can't locate anything Julia related for Mozilla on github, but FYI they fund Julia support:
https://www.zdnet.com/article/mozilla-is-funding-a-way-to-support-julia-in-firefox/
>After porting the Python interpreter to Firefox, Mozilla now wants to support both Julia and R as well.

https://discourse.julialang.org/t/julia-in-firefox/26156


### Reasons for making this change

_TODO_

### Links to a documentation supporting these changes

_TODO_
